### PR TITLE
Fix query string formatting

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -26,7 +26,7 @@ function activate(context) {
           return;
         }
 
-        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url + language + "#q=" + text),1 );
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url + "#q=" + language + " " + text), 1);
     });
 
     context.subscriptions.push(disposable);


### PR DESCRIPTION
As explained [here](https://devdocs.io/help#url_search) the correct format is now `devdocs.io/#q=language search`.

Thanks for creating this extension!