### PR TITLE
Allow user to change regex to match word bounds

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -15,6 +15,7 @@ function activate(context) {
             return; // No open text editor
         }
 
+        const config = vscode.workspace.getConfiguration("devdocs");
         const url = 'https://devdocs.io/';
         let text = "";
 
@@ -23,8 +24,9 @@ function activate(context) {
         if (!selection.isEmpty) {
             text = editor.document.getText(selection);
         } else {
+            const matcher = config.RangeRegex;
             const position = editor.selection.active;
-            const range = editor.document.getWordRangeAtPosition(position);
+            const range = matcher.length == 0 ? editor.document.getWordRangeAtPosition(position) : editor.document.getWordRangeAtPosition(position, new RegExp(matcher, "g"));
             text = editor.document.getText(range);
         }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,17 @@
   ],
   "main": "./extension",
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "devdocs",
+      "properties": {
+        "devdocs.RangeRegex": {
+            "type": "string",
+            "default": "",
+            "description": "Regular expression to find word bounds."
+        }
+      }
+    },
     "commands": [
       {
         "command": "extension.devDocs",


### PR DESCRIPTION
It's allow set language-specific matcher. E.g. `[\w:]+` for C++ to find doc with namespaces